### PR TITLE
Replaced doubles in com.caverock.androidsvg.SVGAndroidRenderer#arcTo() with floats

### DIFF
--- a/src/com/caverock/androidsvg/SVGAndroidRenderer.java
+++ b/src/com/caverock/androidsvg/SVGAndroidRenderer.java
@@ -2567,30 +2567,30 @@ public class SVGAndroidRenderer
 
       // Convert angle from degrees to radians
       float  angleRad = (float) Math.toRadians(angle % 360.0);
-      double cosAngle = Math.cos(angleRad);
-      double sinAngle = Math.sin(angleRad);
+      float cosAngle = (float) Math.cos(angleRad);
+      float sinAngle = (float) Math.sin(angleRad);
       
       // We simplify the calculations by transforming the arc so that the origin is at the
       // midpoint calculated above followed by a rotation to line up the coordinate axes
       // with the axes of the ellipse.
 
       // Compute the midpoint of the line between the current and the end point
-      double dx2 = (lastX - x) / 2.0;
-      double dy2 = (lastY - y) / 2.0;
+      float dx2 = (lastX - x) / 2.0f;
+      float dy2 = (lastY - y) / 2.0f;
 
       // Step 1 : Compute (x1', y1') - the transformed start point
-      double x1 = (cosAngle * dx2 + sinAngle * dy2);
-      double y1 = (-sinAngle * dx2 + cosAngle * dy2);
+      float x1 = (cosAngle * dx2 + sinAngle * dy2);
+      float y1 = (-sinAngle * dx2 + cosAngle * dy2);
 
-      double rx_sq = rx * rx;
-      double ry_sq = ry * ry;
-      double x1_sq = x1 * x1;
-      double y1_sq = y1 * y1;
+      float rx_sq = rx * rx;
+      float ry_sq = ry * ry;
+      float x1_sq = x1 * x1;
+      float y1_sq = y1 * y1;
 
       // Check that radii are large enough.
       // If they are not, the spec says to scale them up so they are.
       // This is to compensate for potential rounding errors/differences between SVG implementations.
-      double radiiCheck = x1_sq / rx_sq + y1_sq / ry_sq;
+      float radiiCheck = x1_sq / rx_sq + y1_sq / ry_sq;
       if (radiiCheck > 1) {
          rx = (float) Math.sqrt(radiiCheck) * rx;
          ry = (float) Math.sqrt(radiiCheck) * ry;
@@ -2599,36 +2599,36 @@ public class SVGAndroidRenderer
       }
 
       // Step 2 : Compute (cx1, cy1) - the transformed centre point
-      double sign = (largeArcFlag == sweepFlag) ? -1 : 1;
-      double sq = ((rx_sq * ry_sq) - (rx_sq * y1_sq) - (ry_sq * x1_sq)) / ((rx_sq * y1_sq) + (ry_sq * x1_sq));
+      float sign = (largeArcFlag == sweepFlag) ? -1 : 1;
+      float sq = ((rx_sq * ry_sq) - (rx_sq * y1_sq) - (ry_sq * x1_sq)) / ((rx_sq * y1_sq) + (ry_sq * x1_sq));
       sq = (sq < 0) ? 0 : sq;
-      double coef = (sign * Math.sqrt(sq));
-      double cx1 = coef * ((rx * y1) / ry);
-      double cy1 = coef * -((ry * x1) / rx);
+      float coef = (float) (sign * Math.sqrt(sq));
+      float cx1 = coef * ((rx * y1) / ry);
+      float cy1 = coef * -((ry * x1) / rx);
 
       // Step 3 : Compute (cx, cy) from (cx1, cy1)
-      double sx2 = (lastX + x) / 2.0;
-      double sy2 = (lastY + y) / 2.0;
-      double cx = sx2 + (cosAngle * cx1 - sinAngle * cy1);
-      double cy = sy2 + (sinAngle * cx1 + cosAngle * cy1);
+      float sx2 = (lastX + x) / 2.0f;
+      float sy2 = (lastY + y) / 2.0f;
+      float cx = sx2 + (cosAngle * cx1 - sinAngle * cy1);
+      float cy = sy2 + (sinAngle * cx1 + cosAngle * cy1);
 
       // Step 4 : Compute the angleStart (angle1) and the angleExtent (dangle)
-      double ux = (x1 - cx1) / rx;
-      double uy = (y1 - cy1) / ry;
-      double vx = (-x1 - cx1) / rx;
-      double vy = (-y1 - cy1) / ry;
-      double p, n;
+      float ux = (x1 - cx1) / rx;
+      float uy = (y1 - cy1) / ry;
+      float vx = (-x1 - cx1) / rx;
+      float vy = (-y1 - cy1) / ry;
+      float p, n;
 
       // Compute the angle start
-      n = Math.sqrt((ux * ux) + (uy * uy));
+      n = (float) Math.sqrt((ux * ux) + (uy * uy));
       p = ux; // (1 * ux) + (0 * uy)
-      sign = (uy < 0) ? -1.0 : 1.0;
-      double angleStart = Math.toDegrees(sign * Math.acos(p / n));
+      sign = (uy < 0) ? -1.0f : 1.0f;
+      float angleStart = (float) Math.toDegrees(sign * Math.acos(p / n));
 
       // Compute the angle extent
-      n = Math.sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
+      n = (float) Math.sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
       p = ux * vx + uy * vy;
-      sign = (ux * vy - uy * vx < 0) ? -1.0 : 1.0;
+      sign = (ux * vy - uy * vx < 0) ? -1.0f : 1.0f;
       double angleExtent = Math.toDegrees(sign * Math.acos(p / n));
       if (!sweepFlag && angleExtent > 0) {
          angleExtent -= 360f;
@@ -2648,7 +2648,7 @@ public class SVGAndroidRenderer
       Matrix m = new Matrix();
       m.postScale(rx, ry);
       m.postRotate(angle);
-      m.postTranslate((float) cx, (float) cy);
+      m.postTranslate(cx, cy);
       m.mapPoints(bezierPoints);
 
       // The last point in the bezier set should match exactly the last coord pair in the arc (ie: x,y). But


### PR DESCRIPTION
Closes https://github.com/BigBadaboom/androidsvg/issues/62.

Only a workaround, so would understand if you don't want to merge, but this fixes the crash we were seeing.