### PR TITLE
Remove deprecated Canvas.save flag.

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
@@ -3882,11 +3882,10 @@ class SVGAndroidRenderer
    // The clip state push and pop methods only save the matrix.
    // The normal push/pop save the clip region also which would
    // destroy the clip region we are trying to build.
-   @SuppressLint("WrongConstant")  // MATRIX_SAVE_FLAG is deprecated and being flagged as an error by Android Studio
    private void  clipStatePush()
    {
       // Save matrix and clip
-      canvas.save(Canvas.MATRIX_SAVE_FLAG);
+      canvas.save();
       // Save style state
       stateStack.push(state);
       state = new RendererState(state);


### PR DESCRIPTION
We can remove this flag as the documentation for this flag says:
Use the flagless version of {@link #save()}

The non-flagless version of Canvas.save is also removed in Android P,
making this library incompatible with P without this change.