### PR TITLE
Use reflection to access legacy Canvas#save(int) to allow compileSdkVersion 28

### DIFF
--- a/androidsvg/build.gradle
+++ b/androidsvg/build.gradle
@@ -1,10 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 27
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -27,4 +29,7 @@ apply from: 'publish.gradle'
 
 dependencies {
     implementation 'org.jetbrains:annotations-java5:15.0'
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:0.5'
 }

--- a/androidsvg/src/androidTest/java/com/caverock/androidsvg/CanvasLegacyTest.java
+++ b/androidsvg/src/androidTest/java/com/caverock/androidsvg/CanvasLegacyTest.java
@@ -1,0 +1,15 @@
+package com.caverock.androidsvg;
+
+import android.graphics.Canvas;
+
+import org.junit.Test;
+
+public class CanvasLegacyTest {
+
+    @Test
+    public void testSave() {
+        final Canvas canvas = new Canvas();
+        CanvasLegacy.save(canvas, CanvasLegacy.MATRIX_SAVE_FLAG);
+        canvas.restore();
+    }
+}

--- a/androidsvg/src/main/java/com/caverock/androidsvg/CanvasLegacy.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/CanvasLegacy.java
@@ -1,0 +1,43 @@
+package com.caverock.androidsvg;
+
+import android.graphics.Canvas;
+
+import java.lang.reflect.Method;
+
+/**
+ * "Aaand it's gone": Canvas#save(int) has been removed from sdk-28,
+ * so this helper classes uses reflection to access the API on older devices.
+ */
+@SuppressWarnings("JavaReflectionMemberAccess")
+class CanvasLegacy {
+    static final int MATRIX_SAVE_FLAG;
+
+    private static final Method SAVE;
+
+    static {
+        try {
+            MATRIX_SAVE_FLAG = (int) Canvas.class.getField("MATRIX_SAVE_FLAG").get(null);
+            SAVE = Canvas.class.getMethod("save", int.class);
+        } catch (Throwable e) {
+            throw sneakyThrow(e);
+        }
+    }
+
+    static void save(Canvas canvas, int saveFlags) {
+        try {
+            SAVE.invoke(canvas, saveFlags);
+        } catch (Throwable e) {
+            throw sneakyThrow(e);
+        }
+    }
+
+    private static RuntimeException sneakyThrow(Throwable t) {
+        if (t == null) throw new NullPointerException("t");
+        return CanvasLegacy.sneakyThrow0(t);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> T sneakyThrow0(Throwable t) throws T {
+        throw (T) t;
+    }
+}

--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
@@ -17,7 +17,6 @@
 package com.caverock.androidsvg;
 
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -3923,11 +3922,10 @@ class SVGAndroidRenderer
    // The clip state push and pop methods only save the matrix.
    // The normal push/pop save the clip region also which would
    // destroy the clip region we are trying to build.
-   @SuppressLint("WrongConstant")  // MATRIX_SAVE_FLAG is deprecated and being flagged as an error by Android Studio
    private void  clipStatePush()
    {
       // Save matrix and clip
-      canvas.save(Canvas.MATRIX_SAVE_FLAG);
+      CanvasLegacy.save(canvas, CanvasLegacy.MATRIX_SAVE_FLAG);
       // Save style state
       stateStack.push(state);
       state = new RendererState(state);


### PR DESCRIPTION
Since `Canvas#save(int)` and `Canvas#MATRIX_SAVE_FLAG` have been removed from the latest android-sdk there is no way to normally call these methods when compiling against sdk-28.

However, since these calls are only required for very old legacy devices, I think using reflection in those cases is fine. The performance overhead is negligible.

Closes BigBadaboom/androidsvg#148: Invalid Layer Save Flag - only ALL_SAVE_FLAGS is allowed