### PR TITLE
Fix the text width calculation in case of a very small text size.

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVGAndroidRenderer.java
@@ -1493,7 +1493,7 @@ class SVGAndroidRenderer
          }
 
          // Update the current text position
-         x += state.fillPaint.measureText(text);
+         x += measureText(text);
       }
    }
 
@@ -1719,10 +1719,30 @@ class SVGAndroidRenderer
          }
 
          // Update the current text position
-         x += state.fillPaint.measureText(text);
+         x += measureText(text);
       }
    }
 
+   /*
+    * Return the text width. 
+	* One cannot use Paint.measureText in all cases since it does Math.ceil on the result.
+	* In case the fractional part of the text size is important (f.e. text size 0.06) the value returned by measureText is very far off the mark.
+	*
+    */
+   private float measureText(String text) {
+      float[] widths=new float[text.length()];
+      state.fillPaint.getTextWidths(text,widths);
+      float res=0;
+      for(float val:widths) {
+         res+=val;
+      }
+      return res;
+      /*float prevSize=state.fillPaint.getTextSize();
+      state.fillPaint.setTextSize(prevSize*100);
+      float res=state.fillPaint.measureText(text);
+      state.fillPaint.setTextSize(prevSize);
+      return res/100;*/
+   }
 
    //==============================================================================
 
@@ -1746,7 +1766,7 @@ class SVGAndroidRenderer
       @Override
       public void processText(String text)
       {
-         x += state.fillPaint.measureText(text);
+         x += measureText(text);
       }
    }
 


### PR DESCRIPTION
Attempt to fix issue #195
It definitely fixes the problem for me.
While I can try to apply post processing of the SVG to change the size of the font to something more seemly I'd rather not. The svg in our system come from a DXF to SVG convertor on the server and recalculating potentially everything in every svg is a waste.