### PR TITLE
 Restructure parser options handling

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/CSSParser.java
@@ -50,6 +50,8 @@ class CSSParser
    private MediaType  deviceMediaType = null;
    private Source     source = null;    // Where these rules came from (Parser or RenderOptions)
 
+   private SVGExternalFileResolver externalFileResolver = null;
+
    private boolean  inMediaRule = false;
 
 
@@ -378,20 +380,21 @@ class CSSParser
    
    CSSParser()
    {
-      this(MediaType.screen, Source.Document);
+      this(MediaType.screen, Source.Document, null);
    }
 
 
-   CSSParser(Source source)
+   CSSParser(Source source, SVGExternalFileResolver externalFileResolver)
    {
-      this(MediaType.screen, source);
+      this(MediaType.screen, source, externalFileResolver);
    }
 
 
-   CSSParser(MediaType rendererMediaType, Source source)
+   CSSParser(MediaType rendererMediaType, Source source, SVGExternalFileResolver externalFileResolver)
    {
       this.deviceMediaType = rendererMediaType;
       this.source = source;
+      this.externalFileResolver = externalFileResolver;
    }
 
 
@@ -1166,8 +1169,8 @@ class CSSParser
          if (!scan.empty() && !scan.consume(';'))
             throw new CSSParseException("Invalid @media rule: expected '}' at end of rule set");
 
-         if (SVG.getFileResolver() != null && mediaMatches(mediaList, deviceMediaType)) {
-            String  css = SVG.getFileResolver().resolveCSSStyleSheet(file);
+         if (externalFileResolver != null && mediaMatches(mediaList, deviceMediaType)) {
+            String  css = externalFileResolver.resolveCSSStyleSheet(file);
             if (css == null)
                return;
             ruleset.addAll( parse(css) );

--- a/androidsvg/src/main/java/com/caverock/androidsvg/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/CSSParser.java
@@ -21,7 +21,7 @@ import android.util.Log;
 import com.caverock.androidsvg.SVG.SvgContainer;
 import com.caverock.androidsvg.SVG.SvgElementBase;
 import com.caverock.androidsvg.SVG.SvgObject;
-import com.caverock.androidsvg.SVGParser.TextScanner;
+import com.caverock.androidsvg.SVGParserImpl.TextScanner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1284,7 +1284,7 @@ class CSSParser
          }
          scan.consume(';');
          // TODO: support CSS only values such as "inherit"
-         SVGParser.processStyleProperty(ruleStyle, propertyName, propertyValue);
+         SVGParserImpl.processStyleProperty(ruleStyle, propertyName, propertyValue);
          scan.skipWhitespace();
          if (scan.empty() || scan.consume('}'))
             break;

--- a/androidsvg/src/main/java/com/caverock/androidsvg/PreserveAspectRatio.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/PreserveAspectRatio.java
@@ -205,7 +205,7 @@ public class PreserveAspectRatio
    public static PreserveAspectRatio  of(String value)
    {
       try {
-         return SVGParser.parsePreserveAspectRatio(value);
+         return SVGParserImpl.parsePreserveAspectRatio(value);
       } catch (SVGParseException e) {
          throw new IllegalArgumentException(e.getMessage());
       }

--- a/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
@@ -38,13 +38,14 @@ import android.graphics.RectF;
 
 public class RenderOptions
 {
-   CSSParser.Ruleset    css = null;
-   //String               id = null;
-   PreserveAspectRatio  preserveAspectRatio = null;
-   String               targetId = null;
-   SVG.Box              viewBox = null;
-   String               viewId = null;
-   SVG.Box              viewPort = null;
+   CSSParser.Ruleset        css = null;
+   //String                 id = null;
+   PreserveAspectRatio      preserveAspectRatio = null;
+   String                   targetId = null;
+   SVG.Box                  viewBox = null;
+   String                   viewId = null;
+   SVG.Box                  viewPort = null;
+   SVGExternalFileResolver  externalFileResolver = null;
 
 
    /**
@@ -82,6 +83,17 @@ public class RenderOptions
       this.viewPort = other.viewPort;
    }
 
+   /**
+    * Register an {@link SVGExternalFileResolver} instance that the renderer should use when resolving
+    * external references such as images, fonts, and CSS stylesheets.
+    *
+    * @param resolver the resolver to use.
+    * @since 1.5
+    */
+   public RenderOptions setExternalFileResolver(SVGExternalFileResolver resolver) {
+      this.externalFileResolver = resolver;
+      return this;
+   }
 
    /**
     * Specifies some additional CSS rules that will be applied during render in addition to
@@ -91,7 +103,7 @@ public class RenderOptions
     */
    public RenderOptions  css(String css)
    {
-      CSSParser  parser = new CSSParser(CSSParser.Source.RenderOptions);
+      CSSParser  parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
       this.css = parser.parse(css);
       return this;
    }

--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVG.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVG.java
@@ -146,7 +146,7 @@ public class SVG
    @SuppressWarnings("WeakerAccess")
    public static SVG  getFromInputStream(InputStream is) throws SVGParseException
    {
-      SVGParser  parser = new SVGParser();
+      SVGParserImpl parser = new SVGParserImpl();
       return parser.parse(is, enableInternalEntities);
    }
 
@@ -161,7 +161,7 @@ public class SVG
    @SuppressWarnings({"WeakerAccess", "unused"})
    public static SVG  getFromString(String svg) throws SVGParseException
    {
-      SVGParser  parser = new SVGParser();
+      SVGParserImpl parser = new SVGParserImpl();
       return parser.parse(new ByteArrayInputStream(svg.getBytes()), enableInternalEntities);
    }
 
@@ -193,7 +193,7 @@ public class SVG
    @SuppressWarnings("WeakerAccess")
    public static SVG  getFromResource(Resources resources, int resourceId) throws SVGParseException
    {
-      SVGParser    parser = new SVGParser();
+      SVGParserImpl parser = new SVGParserImpl();
       InputStream  is = resources.openRawResource(resourceId);
       try {
          return parser.parse(is, enableInternalEntities);
@@ -219,7 +219,7 @@ public class SVG
    @SuppressWarnings({"WeakerAccess", "unused"})
    public static SVG  getFromAsset(AssetManager assetManager, String filename) throws SVGParseException, IOException
    {
-      SVGParser    parser = new SVGParser();
+      SVGParserImpl parser = new SVGParserImpl();
       InputStream  is = assetManager.open(filename);
       try {
          return parser.parse(is, enableInternalEntities);
@@ -261,7 +261,7 @@ public class SVG
     */
    public static android.graphics.Path  parsePath(String pathDefinition)
    {
-      SVG.PathDefinition                pathDef = SVGParser.parsePath(pathDefinition);
+      SVG.PathDefinition                pathDef = SVGParserImpl.parsePath(pathDefinition);
       SVGAndroidRenderer.PathConverter  pathConv = new SVGAndroidRenderer.PathConverter(pathDef);
       return pathConv.getPath();
    }
@@ -769,7 +769,7 @@ public class SVG
       if (this.rootElement == null)
          throw new IllegalArgumentException("SVG document is empty");
 
-      this.rootElement.width = SVGParser.parseLength(value);
+      this.rootElement.width = SVGParserImpl.parseLength(value);
    }
 
 
@@ -826,7 +826,7 @@ public class SVG
       if (this.rootElement == null)
          throw new IllegalArgumentException("SVG document is empty");
 
-      this.rootElement.height = SVGParser.parseLength(value);
+      this.rootElement.height = SVGParserImpl.parseLength(value);
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVGParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVGParser.java
@@ -1,0 +1,63 @@
+/*
+   Copyright 2013 Paul LeBeau, Cave Rock Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package com.caverock.androidsvg;
+
+import java.io.InputStream;
+
+public interface SVGParser
+{
+    /**
+     * Try to parse the stream contents to an {@link SVG} instance.
+     *
+     * @param is Stream to parse
+     * @since 1.5
+     */
+    SVG parseStream(InputStream is) throws SVGParseException;
+
+    /**
+     * Tells the parser whether to allow the expansion of internal entities.
+     * An example of a document containing an internal entities is:
+     *
+     * {@code
+     * <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+     *   <!ENTITY hello "Hello World!">
+     * ]>
+     * <svg>
+     *    <text>&hello;</text>
+     * </svg>
+     * }
+     *
+     * Entities are useful in some circumstances, but SVG files that use them are quite rare.  Note
+     * also that enabling entity expansion makes you vulnerable to the
+     * <a href="https://en.wikipedia.org/wiki/Billion_laughs_attack">Billion Laughs Attack</a>
+     *
+     * Entity expansion is enabled by default.
+     *
+     * @param enable Set true if you want to enable entity expansion by the parser.
+     * @since 1.5
+     */
+    SVGParser setInternalEntitiesEnabled(boolean enable);
+
+    /**
+     * Register an {@link SVGExternalFileResolver} instance that the parser should use when resolving
+     * external references such as images, fonts, and CSS stylesheets.
+     *
+     * @param fileResolver the resolver to use.
+     * @since 1.5
+     */
+    SVGParser setExternalFileResolver(SVGExternalFileResolver fileResolver);
+}

--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVGParserImpl.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVGParserImpl.java
@@ -71,7 +71,7 @@ import javax.xml.parsers.SAXParserFactory;
  * SVG parser code. Used by SVG class. Should not be called directly.
  */
 
-class SVGParser
+class SVGParserImpl
 {
    private static final String  TAG = "SVGParser";
 
@@ -819,21 +819,21 @@ class SVGParser
       @Override
       public void startDocument() throws SAXException
       {
-         SVGParser.this.startDocument();
+         SVGParserImpl.this.startDocument();
       }
 
 
       @Override
       public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException
       {
-         SVGParser.this.startElement(uri, localName, qName, attributes);
+         SVGParserImpl.this.startElement(uri, localName, qName, attributes);
       }
 
 
       @Override
       public void characters(char[] ch, int start, int length) throws SAXException
       {
-         SVGParser.this.text(new String(ch, start, length));
+         SVGParserImpl.this.text(new String(ch, start, length));
       }
 
 
@@ -849,14 +849,14 @@ class SVGParser
       @Override
       public void endElement(String uri, String localName, String qName) throws SAXException
       {
-         SVGParser.this.endElement(uri, localName, qName);
+         SVGParserImpl.this.endElement(uri, localName, qName);
       }
 
 
       @Override
       public void endDocument() throws SAXException
       {
-         SVGParser.this.endDocument();
+         SVGParserImpl.this.endDocument();
       }
 
 
@@ -877,7 +877,7 @@ class SVGParser
 
    private void startDocument()
    {
-      SVGParser.this.svgDocument = new SVG();
+      SVGParserImpl.this.svgDocument = new SVG();
    }
 
 


### PR DESCRIPTION
Instead of having global singletons for parser options (external file resolver, entity expansion), additionally make them settable on a per-parser basis and inherit those properties to the parsed SVG in that case. This allows e.g. having one file resolver per server in case multiple SVGs are fetched and parsed from different servers simultaneously.

Closes #199