### PR TITLE
CSS rule matching optimization

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
@@ -25,6 +25,7 @@ import com.caverock.androidsvg.utils.SVGBase.SvgElementBase;
 import com.caverock.androidsvg.utils.SVGBase.SvgObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -692,9 +693,11 @@ public class CSSParser
       List<SvgContainer> ancestors = new ArrayList<>();
       SvgContainer  parent = obj.parent;
       while (parent != null) {
-         ancestors.add(0, parent);
+         ancestors.add(parent);
          parent = ((SvgObject) parent).parent;
       }
+
+      Collections.reverse(ancestors);
       
       int  ancestorsPos = ancestors.size() - 1;
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
@@ -689,6 +689,10 @@ public class CSSParser
     */
    static boolean  ruleMatch(RuleMatchContext ruleMatchContext, Selector selector, SvgElementBase obj)
    {
+      // Check the most common case first as a shortcut.
+      if (selector.size() == 1)
+         return selectorMatch(ruleMatchContext, selector.get(0), obj);
+
       // Build the list of ancestor objects
       List<SvgContainer> ancestors = new ArrayList<>();
       SvgContainer  parent = obj.parent;
@@ -699,15 +703,9 @@ public class CSSParser
 
       Collections.reverse(ancestors);
       
-      int  ancestorsPos = ancestors.size() - 1;
-
-      // Check the most common case first as a shortcut.
-      if (selector.size() == 1)
-         return selectorMatch(ruleMatchContext, selector.get(0), ancestors, ancestorsPos, obj);
-      
       // We start at the last part of the simpleSelectors and loop back through the parts
       // Get the next simpleSelectors part
-      return ruleMatch(ruleMatchContext, selector, selector.size() - 1, ancestors, ancestorsPos, obj);
+      return ruleMatch(ruleMatchContext, selector, selector.size() - 1, ancestors, ancestors.size() - 1, obj);
    }
 
 
@@ -716,7 +714,7 @@ public class CSSParser
       // We start at the last part of the simpleSelectors and loop back through the parts
       // Get the next simpleSelectors part
       SimpleSelector  sel = selector.get(selPartPos);
-      if (!selectorMatch(ruleMatchContext, sel, ancestors, ancestorsPos, obj))
+      if (!selectorMatch(ruleMatchContext, sel, obj))
          return false;
 
       // Selector part matched, check its combinator
@@ -752,7 +750,7 @@ public class CSSParser
       SimpleSelector  sel = selector.get(selPartPos);
       SvgElementBase  obj = (SvgElementBase) ancestors.get(ancestorsPos);
 
-      if (!selectorMatch(ruleMatchContext, sel, ancestors, ancestorsPos, obj))
+      if (!selectorMatch(ruleMatchContext, sel, obj))
          return false;
 
       // Selector part matched, check its combinator
@@ -799,7 +797,7 @@ public class CSSParser
    }
 
 
-   private static boolean selectorMatch(RuleMatchContext ruleMatchContext, SimpleSelector sel, List<SvgContainer> ancestors, int ancestorsPos, SvgElementBase obj)
+   private static boolean selectorMatch(RuleMatchContext ruleMatchContext, SimpleSelector sel, SvgElementBase obj)
    {
       // Check tag name. tag==null means tag is "*" which matches everything.
       if (sel.tag != null && !sel.tag.equals(obj.getNodeName().toLowerCase(Locale.US)))


### PR DESCRIPTION
I've profiled AndroidSVG a bit and found that `ancestors.add(0, parent);` is so inefficient in CSSParser. It copies all underlying array on each call and it happens on each rule match. So I've replaced it with plain `.add(parent);` and reversed the list in the end.

Also, I've moved the fasttrack `if` branch in ruleMatch() before creating the list of ancestors. It also massively reduced rendering time in our case. 
