### PR TITLE
Add an option to pass parsed CSS Ruleset in RenderOptions.

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/CSS.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/CSS.java
@@ -1,0 +1,33 @@
+package com.caverock.androidsvg;
+
+import com.caverock.androidsvg.utils.CSSBase;
+
+/**
+ * This is a container for pre-parsed CSS that can be used to avoid parsing raw CSS string on each
+ * render. It can be passed to RenderOptions like this:
+ * <pre class="code-block">
+ * {@code
+ * CSS css = CSS.getFromString("...some complex and long css here that takes time to parse...")
+ * RenderOption renderOptions = RenderOptions.create();
+ * renderOptions.css(css) // And now you can reuse the already parsed css
+ * svg1.renderToCanvas(canvas, renderOptions);
+ * svg2.renderToCanvas(canvas, renderOptions);
+ * svg3.renderToCanvas(canvas, renderOptions);
+ * }
+ * </pre>
+ */
+public class CSS extends CSSBase {
+    private CSS(String css)
+    {
+        super(css);
+    }
+
+    /**
+     * @param css css string to parse
+     * @return pre-parsed CSS
+     */
+    public static CSS getFromString(String css)
+    {
+        return new CSS(css);
+    }
+}

--- a/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
@@ -18,7 +18,6 @@ package com.caverock.androidsvg;
 
 import android.graphics.Canvas;
 
-import com.caverock.androidsvg.utils.CSSParser;
 import com.caverock.androidsvg.utils.RenderOptionsBase;
 
 /**
@@ -73,7 +72,7 @@ public class RenderOptions extends RenderOptionsBase
 
    /**
     * Specifies some additional CSS rules that will be applied during render in addition to
-    * any specified in the file itself.
+    * any specified in the file itself. CSS will be parsed during SVG render.
     * @param css CSS rules to apply
     * @return this same <code>RenderOptions</code> instance
     */
@@ -84,14 +83,14 @@ public class RenderOptions extends RenderOptionsBase
 
 
    /**
-    * Specifies some already parsed CSS Ruleset that will be applied during render in
-    * addition toany specified in the file itself.
-    * @param cssRuleset CSS rules to apply
+    * Specifies some additional CSS that will be applied during render in
+    * addition to any specified in the file itself.
+    * @param css CSS rules to apply
     * @return this same <code>RenderOptions</code> instance
     */
-   public RenderOptions  cssRuleset(CSSParser.Ruleset cssRuleset)
+   public RenderOptions  css(CSS css)
    {
-      return (RenderOptions) super.cssRuleset(cssRuleset);
+      return (RenderOptions) super.css(css);
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/RenderOptions.java
@@ -18,6 +18,7 @@ package com.caverock.androidsvg;
 
 import android.graphics.Canvas;
 
+import com.caverock.androidsvg.utils.CSSParser;
 import com.caverock.androidsvg.utils.RenderOptionsBase;
 
 /**
@@ -69,6 +70,7 @@ public class RenderOptions extends RenderOptionsBase
       super(other);
    }
 
+
    /**
     * Specifies some additional CSS rules that will be applied during render in addition to
     * any specified in the file itself.
@@ -78,6 +80,18 @@ public class RenderOptions extends RenderOptionsBase
    public RenderOptions  css(String css)
    {
       return (RenderOptions) super.css(css);
+   }
+
+
+   /**
+    * Specifies some already parsed CSS Ruleset that will be applied during render in
+    * addition toany specified in the file itself.
+    * @param cssRuleset CSS rules to apply
+    * @return this same <code>RenderOptions</code> instance
+    */
+   public RenderOptions  cssRuleset(CSSParser.Ruleset cssRuleset)
+   {
+      return (RenderOptions) super.cssRuleset(cssRuleset);
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSBase.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSBase.java
@@ -1,0 +1,13 @@
+package com.caverock.androidsvg.utils;
+
+/*
+    This is just a link to CSSParser class. As CSSParser is package-protected and we don't want it
+    to leak as a public API, we just gaining access through this inheritance.
+ */
+public class CSSBase {
+    protected CSSParser.Ruleset cssRuleset;
+
+    protected CSSBase(String css) {
+        this.cssRuleset = new CSSParser(CSSParser.Source.RenderOptions, null).parse(css);
+    }
+}

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
@@ -386,13 +386,13 @@ public class CSSParser
    }
 
 
-   public CSSParser(Source source, SVGExternalFileResolver externalFileResolver)
+   CSSParser(Source source, SVGExternalFileResolver externalFileResolver)
    {
       this(MediaType.screen, source, externalFileResolver);
    }
 
 
-   public CSSParser(MediaType rendererMediaType, Source source, SVGExternalFileResolver externalFileResolver)
+   CSSParser(MediaType rendererMediaType, Source source, SVGExternalFileResolver externalFileResolver)
    {
       this.deviceMediaType = rendererMediaType;
       this.source = source;
@@ -400,7 +400,7 @@ public class CSSParser
    }
 
 
-   public Ruleset  parse(String sheet)
+   Ruleset  parse(String sheet)
    {
       CSSTextScanner  scan = new CSSTextScanner(sheet);
       scan.skipWhitespace();

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSParser.java
@@ -386,13 +386,13 @@ public class CSSParser
    }
 
 
-   CSSParser(Source source, SVGExternalFileResolver externalFileResolver)
+   public CSSParser(Source source, SVGExternalFileResolver externalFileResolver)
    {
       this(MediaType.screen, source, externalFileResolver);
    }
 
 
-   CSSParser(MediaType rendererMediaType, Source source, SVGExternalFileResolver externalFileResolver)
+   public CSSParser(MediaType rendererMediaType, Source source, SVGExternalFileResolver externalFileResolver)
    {
       this.deviceMediaType = rendererMediaType;
       this.source = source;
@@ -400,7 +400,7 @@ public class CSSParser
    }
 
 
-   Ruleset  parse(String sheet)
+   public Ruleset  parse(String sheet)
    {
       CSSTextScanner  scan = new CSSTextScanner(sheet);
       scan.skipWhitespace();

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
@@ -99,12 +99,14 @@ public class RenderOptionsBase
    public RenderOptionsBase css(CSS css)
    {
       this.cssRuleset = css.cssRuleset;
+      this.css = null;
       return this;
    }
 
    public RenderOptionsBase css(String css)
    {
       this.css = css;
+      this.cssRuleset = null;
       return this;
    }
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
@@ -43,6 +43,7 @@ import com.caverock.androidsvg.utils.SVGBase.Box;
 public class RenderOptionsBase
 {
    String               css = null;
+   CSSParser.Ruleset    cssRuleset = null;
    //String             id = null;
    PreserveAspectRatio  preserveAspectRatio = null;
    String               targetId = null;
@@ -79,6 +80,7 @@ public class RenderOptionsBase
       if (other == null)
          return;
       this.css = other.css;
+      this.cssRuleset = other.cssRuleset;
       //this.id = other.id;
       this.preserveAspectRatio = other.preserveAspectRatio;
       this.viewBox = other.viewBox;
@@ -99,6 +101,18 @@ public class RenderOptionsBase
       return this;
    }
 
+   /**
+    * Specifies some already parsed CSS Ruleset that will be applied during render in
+    * addition toany specified in the file itself.
+    * @param cssRuleset CSS rules to apply
+    * @return this same <code>RenderOptions</code> instance
+    */
+   public RenderOptionsBase cssRuleset(CSSParser.Ruleset cssRuleset)
+   {
+      this.cssRuleset = cssRuleset;
+      return this;
+   }
+
 
    /**
     * Returns true if this RenderOptions instance has had CSS set with {@code css()}.
@@ -107,6 +121,16 @@ public class RenderOptionsBase
    public boolean hasCss()
    {
       return this.css != null && this.css.trim().length() > 0;
+   }
+
+
+   /**
+    * Returns true if this RenderOptions instance has had CSS Ruleset set with {@code cssRuleset()}.
+    * @return true if this RenderOptions instance has had CSS Ruleset set
+    */
+   public boolean hasCssRuleset()
+   {
+      return this.cssRuleset != null;
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/RenderOptionsBase.java
@@ -18,6 +18,7 @@ package com.caverock.androidsvg.utils;
 
 import android.graphics.Canvas;
 
+import com.caverock.androidsvg.CSS;
 import com.caverock.androidsvg.PreserveAspectRatio;
 import com.caverock.androidsvg.RenderOptions;
 import com.caverock.androidsvg.SVG;
@@ -90,11 +91,17 @@ public class RenderOptionsBase
    }
 
    /**
-    * Specifies some additional CSS rules that will be applied during render in addition to
-    * any specified in the file itself.
+    * Specifies some already parsed CSS that will be applied during render in
+    * addition to any specified in the file itself.
     * @param css CSS rules to apply
     * @return this same <code>RenderOptions</code> instance
     */
+   public RenderOptionsBase css(CSS css)
+   {
+      this.cssRuleset = css.cssRuleset;
+      return this;
+   }
+
    public RenderOptionsBase css(String css)
    {
       this.css = css;
@@ -102,35 +109,12 @@ public class RenderOptionsBase
    }
 
    /**
-    * Specifies some already parsed CSS Ruleset that will be applied during render in
-    * addition toany specified in the file itself.
-    * @param cssRuleset CSS rules to apply
-    * @return this same <code>RenderOptions</code> instance
-    */
-   public RenderOptionsBase cssRuleset(CSSParser.Ruleset cssRuleset)
-   {
-      this.cssRuleset = cssRuleset;
-      return this;
-   }
-
-
-   /**
     * Returns true if this RenderOptions instance has had CSS set with {@code css()}.
     * @return true if this RenderOptions instance has had CSS set
     */
    public boolean hasCss()
    {
-      return this.css != null && this.css.trim().length() > 0;
-   }
-
-
-   /**
-    * Returns true if this RenderOptions instance has had CSS Ruleset set with {@code cssRuleset()}.
-    * @return true if this RenderOptions instance has had CSS Ruleset set
-    */
-   public boolean hasCssRuleset()
-   {
-      return this.cssRuleset != null;
+      return this.css != null && this.css.trim().length() > 0 || this.cssRuleset != null;
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
@@ -339,9 +339,7 @@ public class SVGAndroidRenderer
          if (renderOptions.css != null) {
             CSSParser parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
             document.addCSSRules(parser.parse(renderOptions.css));
-         }
-
-         if (renderOptions.cssRuleset != null) {
+         } else if (renderOptions.cssRuleset != null) {
             document.addCSSRules(renderOptions.cssRuleset);
          }
       }

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
@@ -336,11 +336,14 @@ public class SVGAndroidRenderer
       }
 
       if (renderOptions.hasCss()) {
-            CSSParser  parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
+         if (renderOptions.css != null) {
+            CSSParser parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
             document.addCSSRules(parser.parse(renderOptions.css));
-      }
-      if (renderOptions.hasCssRuleset()) {
-         document.addCSSRules(renderOptions.cssRuleset);
+         }
+
+         if (renderOptions.cssRuleset != null) {
+            document.addCSSRules(renderOptions.cssRuleset);
+         }
       }
       if (renderOptions.hasTarget()) {
          this.ruleMatchContext = new CSSParser.RuleMatchContext();

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
@@ -336,8 +336,11 @@ public class SVGAndroidRenderer
       }
 
       if (renderOptions.hasCss()) {
-         CSSParser  parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
-         document.addCSSRules(parser.parse(renderOptions.css));
+            CSSParser  parser = new CSSParser(CSSParser.Source.RenderOptions, externalFileResolver);
+            document.addCSSRules(parser.parse(renderOptions.css));
+      }
+      if (renderOptions.hasCssRuleset()) {
+         document.addCSSRules(renderOptions.cssRuleset);
       }
       if (renderOptions.hasTarget()) {
          this.ruleMatchContext = new CSSParser.RuleMatchContext();


### PR DESCRIPTION
Add a possibility to parse CSS separately from SVG and reuse this already parsed CSS Rulesets when rendering.

We're rendering a lot of small svg documents that share a common css and this optimization saved us about 75% of rendering time.

