### PR TITLE
Use precompiled Patterns for replaceAll

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSTextScanner.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/CSSTextScanner.java
@@ -18,12 +18,15 @@ package com.caverock.androidsvg.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class CSSTextScanner extends TextScanner
 {
+   static final Pattern PATTERN_BLOCK_COMMENTS = Pattern.compile("(?s)/\\*.*?\\*/");
+
    public CSSTextScanner(String input)
    {
-      super(input.replaceAll("(?s)/\\*.*?\\*/", ""));  // strip all block comments
+      super(PATTERN_BLOCK_COMMENTS.matcher(input).replaceAll(""));  // strip all block comments
    }
 
    /*

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
@@ -123,6 +123,12 @@ public class SVGAndroidRenderer
    private static final boolean  SUPPORTS_BLEND_MODE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;          // Android 10
    private static final boolean  SUPPORTS_PAINT_WORD_SPACING = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
 
+   private static final java.util.regex.Pattern PATTERN_TABS_OR_LINE_BREAKS = java.util.regex.Pattern.compile("[\\n\\t]");
+   private static final java.util.regex.Pattern PATTERN_TABS = java.util.regex.Pattern.compile("\\t");
+   private static final java.util.regex.Pattern PATTERN_LINE_BREAKS = java.util.regex.Pattern.compile("\\n");
+   private static final java.util.regex.Pattern PATTERN_START_SPACES = java.util.regex.Pattern.compile("^\\s+");
+   private static final java.util.regex.Pattern PATTERN_END_SPACES = java.util.regex.Pattern.compile("\\s+$");
+   private static final java.util.regex.Pattern PATTERN_DOUBLE_SPACES = java.util.regex.Pattern.compile("\\s{2,}");
 
    private final Canvas   canvas;
    private final float    dpi;    // dots per inch. Needed for accurate conversion of length values that have real world units, such as "cm".
@@ -2022,22 +2028,21 @@ public class SVGAndroidRenderer
 
    //==============================================================================
 
-
    // Process the text string according to the xml:space rules
    private String  textXMLSpaceTransform(String text, boolean isFirstChild, boolean isLastChild)
    {
       if (state.spacePreserve)  // xml:space = "preserve"
-         return text.replaceAll("[\\n\\t]", " ");
+         return PATTERN_TABS_OR_LINE_BREAKS.matcher(text).replaceAll(" ");
 
       // xml:space = "default"
-      text = text.replaceAll("\\n", "");
-      text = text.replaceAll("\\t", " ");
+      text = PATTERN_TABS.matcher(text).replaceAll("");
+      text = PATTERN_LINE_BREAKS.matcher(text).replaceAll(" ");
       //text = text.trim();
       if (isFirstChild)
-         text = text.replaceAll("^\\s+",  "");
+         text = PATTERN_START_SPACES.matcher(text).replaceAll("");
       if (isLastChild)
-         text = text.replaceAll("\\s+$",  "");
-      return text.replaceAll("\\s{2,}", " ");
+         text = PATTERN_END_SPACES.matcher(text).replaceAll("");
+      return PATTERN_DOUBLE_SPACES.matcher(text).replaceAll(" ");
    }
 
 

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGParserImpl.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGParserImpl.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -88,6 +89,8 @@ class SVGParserImpl implements SVGParser
    // nextToken() method. Also, they throw an exception when calling setFeature().
    // So for simplicity, we'll just force the use of the SAX parser on Androids < 15.
    private static final boolean FORCE_SAX_ON_EARLY_ANDROIDS = (android.os.Build.VERSION.SDK_INT < 15);
+
+   private static final Pattern PATTERN_BLOCK_COMMENTS = Pattern.compile("/\\*.*?\\*/");
 
    // <?xml-stylesheet> attribute names and values
    public static final String  XML_STYLESHEET_ATTR_TYPE = "type";
@@ -2659,7 +2662,7 @@ class SVGParserImpl implements SVGParser
     */
    private static void  parseStyle(SvgElementBase obj, String style)
    {
-      CSSTextScanner  scan = new CSSTextScanner(style.replaceAll("/\\*.*?\\*/", ""));  // regex strips block comments
+      CSSTextScanner  scan = new CSSTextScanner(PATTERN_BLOCK_COMMENTS.matcher(style).replaceAll(""));  // regex strips block comments
 
       while (!scan.empty())
       {


### PR DESCRIPTION
Hi Paul,
Found another optimization. `textXMLSpaceTransform` was eating so much of CPU because it compiled regexes each time. Now it's precompiled and cached and I got 30% rendering boost on our testing case on this.(Yep, we've a lot of text nodes in our svg)

With regards,