### PR TITLE
Click events for SVG Elements

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/SVG.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/SVG.java
@@ -27,6 +27,7 @@ import com.caverock.androidsvg.utils.SVGBase;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -738,5 +739,9 @@ public class SVG
    SVGBase.Svg  getRootElement()
    {
       return base.getRootElement();
+   }
+
+   Collection<SVGBase.SvgObject> getElementsAt(float x, float y) {
+      return base.getElementsAt(x, y, true);
    }
 }

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGAndroidRenderer.java
@@ -422,6 +422,10 @@ public class SVGAndroidRenderer
          render((Text) obj);
       }
 
+      if(obj instanceof SvgElementBase && ((SvgElementBase) obj).id != null){
+         document.putElementById(((SvgElementBase) obj).id, (SvgElementBase) obj);
+      }
+
       // Restore state
       statePop();
    }

--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGBase.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGBase.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2127,6 +2128,11 @@ public class SVGBase
    }
 
 
+   SvgElementBase putElementById(String id, SvgElementBase obj) {
+      return idToElementMap.put(id, obj);
+   }
+
+
    SvgElementBase  getElementById(String id)
    {
       if (id == null || id.length() == 0)
@@ -2190,5 +2196,40 @@ public class SVGBase
       }
    }
 
+   public Collection<SvgObject> getElementsAt(float x, float y, boolean withIdsOnly)
+   {
+      List<SvgObject>  result = new ArrayList<>();
 
+      // Search the object tree for nodes at the given coordinates
+      if(!withIdsOnly){
+         getElementsAt(result, rootElement, x, y);
+      } else {
+         for (SvgElementBase obj: idToElementMap.values()){
+            if(obj instanceof SvgElement && containsCoords((SvgElement) obj, x, y)){
+               result.add((SvgElement) obj);
+            }
+         }
+      }
+      return result;
+   }
+
+
+   private void  getElementsAt(List<SvgObject> result, SvgObject obj, float x, float y)
+   {
+      if (obj instanceof SvgContainer)
+      {
+         for (SvgObject child: ((SvgContainer) obj).getChildren())
+            getElementsAt(result, child, x, y);
+
+      } else if (obj instanceof SvgElement && containsCoords((SvgElement) obj, x, y)) {
+            result.add((SvgElement) obj);
+      }
+   }
+
+   private boolean containsCoords(SvgElement elm, float x, float y){
+      Box box = elm.boundingBox;
+      if (box != null)
+         return (x >= box.minX && x <= box.maxX() && y >= box.minY && y <= box.maxY());
+      else return false;
+   }
 }


### PR DESCRIPTION
Hey Paul,

Before I went ahead and added more flexibilities and features for click events, I thought I'd review with you some of the changes on `SVG` and `SVGBase`.

- SVGBase
I added couple of methods for us to fetch all elements at a specific location, which can be restricted to only elements with ids. We could move `containsCoords` into `Box` as it's more of a helper method for `Box`.
- SVG
Just exposing `getElementsAt` from base.
- SVGRenderer
Rather than fetching for ids, I thought we might as well put them in `idToElementMap` while creating the render tree. We could change this to `getIdToElementMap().put(id, obj)`. Moreover we can then expose `getIdToElementMap()`.

Let me know what you think.

Ishan