### PR TITLE
Switch to SAX parser when finding ATTLIST

### DIFF
--- a/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGParserImpl.java
+++ b/androidsvg/src/main/java/com/caverock/androidsvg/utils/SVGParserImpl.java
@@ -642,7 +642,7 @@ class SVGParserImpl implements SVGParser
             String preamble = new String(checkBuf, 0, n);
             // Reset the stream so that the XML parsers can do their job.
             is.reset();
-            if (preamble.contains("<!ENTITY ")) {
+            if (preamble.contains("<!ENTITY ") || preamble.contains("<!ATTLIST ")) {
                // Found something that looks like an entity definition.
                // So we'll use the SAX parser which supports them.
                debug("Switching to SAX parser to process entities");


### PR DESCRIPTION
Simple fix to support `ATTLIST` just like it is done with `ENTITY`.

Issue references:
- https://github.com/deckerst/aves/issues/1428
- https://github.com/coil-kt/coil/issues/2853

Sample:
![ATTLIST_sample](https://github.com/user-attachments/assets/bf035f59-6f75-4428-9381-49803612f705)
